### PR TITLE
Handle special characters in suite, test, and error texts

### DIFF
--- a/src/utils/html_template.js
+++ b/src/utils/html_template.js
@@ -92,6 +92,7 @@ export function getHtmlTemplete(suites, specs, options, passRate, totalDuration,
                     margin-bottom: 20px;
                     padding: 15px;
                     border-radius: 4px;
+                    background-color: #d4edda;
                 }
                 .test.passed {
                     background-color: #d4edda;

--- a/src/utils/render_suites.js
+++ b/src/utils/render_suites.js
@@ -26,7 +26,7 @@ function renderSuite(suite) {
 
       <div class="suite">
         <div class="suite-header">
-          <div class="suite-title">${suite.title}</div>
+          <div class="suite-title">${escapeHtml(suite.title)}</div>
           <div class="suite-stats">
             Tests: ${total} | Passed: ${passed} | Failed: ${failed} | Skipped: ${skipped}
           </div>
@@ -45,7 +45,7 @@ function renderTests(suite) {
       test => `
         <div class="test ${test.state}">
             <div class="test-header">
-                <div class="test-title">${test.title}</div>
+                <div class="test-title">${escapeHtml(test.title)}</div>
                 <div class="test-duration">${test.duration}ms</div>
             </div>
             
@@ -53,8 +53,8 @@ function renderTests(suite) {
               test.error
                 ? `
             <div class="test-error">
-                <strong>Error:</strong> ${test.error.message}
-                <pre>${test.error.stack}</pre>
+                <strong>Error:</strong> ${escapeHtml(test.error.message || '')}
+                <pre>${escapeHtml(test.error.stack || '')}</pre>
             </div>
             `
                 : ''

--- a/test/reporter.spec.js
+++ b/test/reporter.spec.js
@@ -79,7 +79,7 @@ describe('Custom HtmlReporter', function () {
       title: 'Test 2',
       parentUid: 's3',
       duration: 123,
-      error: { message: 'Oops', stack: 'stacktrace' },
+      error: { message: 'Oops', stack: 'stacktrace <stack>' },
     };
 
     reporter.onSuiteStart(suite);
@@ -98,7 +98,7 @@ describe('Custom HtmlReporter', function () {
     const suite = { uid: 's4', title: 'Suite 4', parentUid: null };
     const test = {
       uid: 't3',
-      title: 'Test 3',
+      title: 'Test 3 <special_tags>',
       parentUid: 's4',
       duration: 100,
     };


### PR DESCRIPTION
# 📢 Description

### Problem
If any suite or test title contains specials characters for example <publish> then it was not getting logged in the report as `<` and `>` are special characters in HTML.

### Solution
In this PR, we are escaping such special characters.
